### PR TITLE
fix(autoload/inflow.vim): default width 80 -> 79

### DIFF
--- a/autoload/inflow.vim
+++ b/autoload/inflow.vim
@@ -8,7 +8,7 @@ function! inflow#setlocal_formatprg() " {{{
     let s:my_textwidth = &textwidth
 
     if s:my_textwidth <= 0
-        s:my_textwidth = get(g:, 'inflow_default_width', 80)
+        s:my_textwidth = get(g:, 'inflow_default_width', 79)
     endif
 
     " There may be a better way to set the `formatprg` value


### PR DESCRIPTION
I noticed this plugin sets the default width to 80 instead of inflow's [default of 79](https://github.com/stephen-huan/inflow/blob/e8d1a094f284e133487d41be20eef27a6e8f7b02/src/inflow/inflow.py#L141). Was there a reason for this? Note that inflow's width is _inclusive_, that is, `inflow 79` allows lines to have width 79 (or less); this matches vim's `textwidth`.